### PR TITLE
Fixed off-by-one in `to_hex`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,17 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Natural Language :: English",
 ]
-dependencies = []
+dependencies = ["black", "setuptools", "wheel", "nanobind"]
+
+[project.optional-dependencies]
+dev = [
+    "black",
+    "benchmark",
+    "coverage",
+    "pytest",
+    "pytest-cov",
+    "pytest-benchmark",
+]
 
 [project.urls]
 Homepage = "https://github.com/calladoum-elastic/tlsh"
@@ -29,3 +39,8 @@ wheel.py-api = "cp312"
 minimum-version = "0.4"
 build-dir = "build/{wheel_tag}"
 cmake.minimum-version = "3.20"
+
+# Uncomment for debug (+ASAN)
+# cmake.verbose = true
+# logging.level = "DEBUG"
+# cmake.build-type = "Debug"

--- a/python/tests/test_tlsh.py
+++ b/python/tests/test_tlsh.py
@@ -41,14 +41,16 @@ def test_basic_test():
     assert isinstance(val2, bytes)
     assert val2.startswith(b"T1")
 
-    for _ in range(100):
+    for _ in range(2000):
         a = tlsh.Tlsh()
         a.update(buf)
         a.final()
+        assert a.valid
 
         b = tlsh.Tlsh()
         b.update(buf)
         b.final()
+        assert b.valid
 
         assert bool(a)
         assert isinstance(a.hexdigest(), str)
@@ -73,9 +75,11 @@ def test_load_string():
     input_b = "T1B0524126A7A1CF3EDD3893B804A74631A2B67898A37522372755B7342F933544AA34C9"
     a = tlsh.Tlsh()
     a.load(input_a)
+    assert a.valid
     assert a.hexdigest() == input_a
     b = tlsh.Tlsh()
     b.load(input_b)
+    assert b.valid
     assert b.hexdigest(ver=1) == input_b
 
 
@@ -182,3 +186,24 @@ def test_perf_tlsh_load(benchmark):
         "5F52FA2AFBA1C9BDDCBCE3F484570170B2B6786153B6623B269467341F933445A538E8",
     )
     assert isinstance(result, int)
+
+
+DIFF_TESTCASES = [
+    # (hash1, hash2, expected_score)
+    [
+        "T17E16D300ACF0A8D1D44DB37A95DC19249EE71EC38D30695EBBDCEC9D1F216884DE269B",
+        "T17E16D300ACF0A8D1D44DB37A95DC19249EE71EC38D30695EBBDCEC9D1F216884DE26AA",
+        2,
+    ]
+]
+
+
+def test_diff():
+    for tc in DIFF_TESTCASES:
+        t1 = tlsh.Tlsh()
+        assert t1.load(tc[0])
+        assert t1.valid
+        t2 = tlsh.Tlsh()
+        assert t2.load(tc[1])
+        assert t2.valid
+        assert t1.diff(t2, False) == tc[2]

--- a/python/tlsh/__init__.py
+++ b/python/tlsh/__init__.py
@@ -16,6 +16,10 @@ class Tlsh:
             self.update(buffer)
 
     def __bool__(self) -> bool:
+        return self.valid
+
+    @property
+    def valid(self) -> bool:
         return self._tlsh_obj.isValid()
 
     def update(self, buffer: Union[bytes, bytearray]) -> None:

--- a/src/tlsh.cpp
+++ b/src/tlsh.cpp
@@ -150,7 +150,9 @@ const std::string
 Tlsh::getHash(u8 showvers) const
 {
     auto const &res = m_Implementation->hash(showvers);
-    return std::string((char*)res.data(), res.size());
+    if (res.size() == 0)
+        return "";
+    return std::string((char *)res.data(), res.size());
 }
 
 // const char *

--- a/src/tlsh_impl.cpp
+++ b/src/tlsh_impl.cpp
@@ -83,21 +83,19 @@ partition(unsigned int *buf, unsigned int left, unsigned int right);
 
 TlshImpl::TlshImpl() : a_bucket{nullptr}, data_len{0}, lsh_code{}, lsh_code_valid{false}
 {
-    memset(this->slide_window.data(), 0, sizeof(this->slide_window.size()));
+    memset(this->slide_window.data(), 0, this->slide_window.size());
     memset(&this->lsh_bin, 0, sizeof(this->lsh_bin));
 
     assert(sizeof(this->lsh_bin.Q.QR) == sizeof(this->lsh_bin.Q.QB));
 }
 
-TlshImpl::~TlshImpl()
-{
-}
+TlshImpl::~TlshImpl() = default;
 
 void
 TlshImpl::reset()
 {
     this->a_bucket.reset();
-    memset(this->slide_window.data(), 0, sizeof(this->slide_window.size()));
+    memset(this->slide_window.data(), 0, this->slide_window.size());
 
     this->lsh_code.clear();
     this->lsh_code.resize(0);
@@ -110,6 +108,7 @@ TlshImpl::reset()
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 // Pearson's sample random table
+// clang-format off
 static std::array<u8, 256> v_table = {1, 87, 49, 12, 176, 178, 102, 166, 121, 193, 6, 84, 249, 230,
     44, 163, 14, 197, 213, 181, 161, 85, 218, 80, 64, 239, 24, 226, 236, 142, 38, 200, 110, 177,
     104, 103, 141, 253, 255, 50, 77, 101, 81, 18, 45, 96, 31, 222, 25, 107, 190, 70, 86, 237, 240,
@@ -125,263 +124,24 @@ static std::array<u8, 256> v_table = {1, 87, 49, 12, 176, 178, 102, 166, 121, 19
     28, 144, 254, 221, 93, 189, 194, 139, 112, 43, 71, 109, 184, 209};
 
 static std::array<u8, 256> v_table48 = {
-    1,
-    39,
-    1,
-    12,
-    32,
-    34,
-    6,
-    22,
-    25,
-    1,
-    6,
-    36,
-    48,
-    38,
-    44,
-    19,
-    14,
-    5,
-    21,
-    37,
-    17,
-    37,
-    26,
-    32,
-    16,
-    47,
-    24,
-    34,
-    44,
-    46,
-    38,
-    8,
-    14,
-    33,
-    8,
-    7,
-    45,
-    48,
-    48,
-    2,
-    29,
-    5,
-    33,
-    18,
-    45,
-    0,
-    31,
-    30,
-    25,
-    11,
-    46,
-    22,
-    38,
-    45,
-    48,
-    34,
-    24,
-    48,
-    20,
-    22,
-    48,
-    35,
-    5,
-    43,
-    1,
-    42,
-    9,
-    22,
-    12,
-    48,
-    34,
-    31,
-    16,
-    5,
-    31,
-    7,
-    15,
-    14,
-    39,
-    48,
-    30,
-    25,
-    19,
-    10,
-    18,
-    10,
-    10,
-    3,
-    48,
-    27,
-    17,
-    43,
-    38,
-    35,
-    0,
-    48,
-    36,
-    8,
-    4,
-    27,
-    32,
-    37,
-    14,
-    4,
-    34,
-    30,
-    43,
-    13,
-    9,
-    48,
-    24,
-    27,
-    23,
-    20,
-    31,
-    30,
-    35,
-    40,
-    9,
-    3,
-    26,
-    11,
-    44,
-    32,
-    40,
-    18,
-    4,
-    10,
-    42,
-    30,
-    0,
-    39,
-    12,
-    35,
-    13,
-    26,
-    47,
-    26,
-    48,
-    46,
-    33,
-    18,
-    15,
-    8,
-    26,
-    7,
-    19,
-    23,
-    48,
-    14,
-    3,
-    6,
-    7,
-    11,
-    7,
-    28,
-    42,
-    5,
-    23,
-    35,
-    29,
-    29,
-    15,
-    46,
-    31,
-    47,
-    41,
-    16,
-    9,
-    41,
-    33,
-    32,
-    25,
-    16,
-    37,
-    27,
-    22,
-    25,
-    2,
-    13,
-    46,
-    20,
-    9,
-    1,
-    38,
-    36,
-    15,
-    20,
-    10,
-    23,
-    21,
-    37,
-    27,
-    44,
-    19,
-    28,
-    24,
-    48,
-    42,
-    4,
-    29,
-    12,
-    21,
-    48,
-    19,
-    13,
-    39,
-    11,
-    41,
-    40,
-    42,
-    3,
-    6,
-    0,
-    11,
-    33,
-    20,
-    47,
-    2,
-    12,
-    21,
-    36,
-    21,
-    28,
-    44,
-    36,
-    18,
-    28,
-    41,
-    6,
-    15,
-    8,
-    41,
-    40,
-    17,
-    4,
-    39,
-    47,
-    2,
-    24,
-    3,
-    17,
-    28,
-    0,
-    48,
-    29,
-    45,
-    45,
-    2,
-    43,
-    16,
-    43,
-    23,
-    13,
-    40,
-    17,
+	1, 39, 1, 12, 32, 34, 6, 22, 25, 1, 6, 36, 48, 38, 44, 19,
+	14, 5, 21, 37, 17, 37, 26, 32, 16, 47, 24, 34, 44, 46, 38, 8,
+	14, 33, 8, 7, 45, 48, 48, 2, 29, 5, 33, 18, 45, 0, 31, 30,
+	25, 11, 46, 22, 38, 45, 48, 34, 24, 48, 20, 22, 48, 35, 5, 43,
+	1, 42, 9, 22, 12, 48, 34, 31, 16, 5, 31, 7, 15, 14, 39, 48,
+	30, 25, 19, 10, 18, 10, 10, 3, 48, 27, 17, 43, 38, 35, 0, 48,
+	36, 8, 4, 27, 32, 37, 14, 4, 34, 30, 43, 13, 9, 48, 24, 27,
+	23, 20, 31, 30, 35, 40, 9, 3, 26, 11, 44, 32, 40, 18, 4, 10,
+	42, 30, 0, 39, 12, 35, 13, 26, 47, 26, 48, 46, 33, 18, 15, 8,
+	26, 7, 19, 23, 48, 14, 3, 6, 7, 11, 7, 28, 42, 5, 23, 35,
+	29, 29, 15, 46, 31, 47, 41, 16, 9, 41, 33, 32, 25, 16, 37, 27,
+	22, 25, 2, 13, 46, 20, 9, 1, 38, 36, 15, 20, 10, 23, 21, 37,
+	27, 44, 19, 28, 24, 48, 42, 4, 29, 12, 21, 48, 19, 13, 39, 11,
+	41, 40, 42, 3, 6, 0, 11, 33, 20, 47, 2, 12, 21, 36, 21, 28,
+	44, 36, 18, 28, 41, 6, 15, 8, 41, 40, 17, 4, 39, 47, 2, 24,
+	3, 17, 28, 0, 48, 29, 45, 45, 2, 43, 16, 43, 23, 13, 40, 17,
 };
+// clang-format on
 
 // Pearson's algorithm
 unsigned char
@@ -1174,15 +934,8 @@ TlshImpl::fromTlshStr(std::string const &str)
     }
 
     // Assume that we have 128 Buckets
-    int start = 0;
-    if (str.substr(0, 2) == "T1")
-    {
-        start = 2;
-    }
-    else
-    {
-        start = 0;
-    }
+    const u32 start = (str.substr(0, 2) == "T1") ? 2 : 0;
+
     // Validate input string
     for (int ii = 0; ii < INTERNAL_TLSH_STRING_LEN; ii++)
     {
@@ -1202,11 +955,17 @@ TlshImpl::fromTlshStr(std::string const &str)
         return 1;
     }
 
-    std::vector<u8> buf;
-    buf.assign(&str[start], &str[str.size() - start]);
+    const size_t sz = str.size() - start;
+    std::vector<u8> buf(sz);
+    buf.assign(&str[start], &str[start + sz]);
 
-    std::vector<u8> result(sizeof(buf));
+    std::vector<u8> result;
     from_hex(buf, result);
+
+    if (result.empty())
+    {
+        return 1;
+    }
 
     return this->fromTlshBytes(result);
 }
@@ -1216,7 +975,14 @@ TlshImpl::fromTlshBytes(std::vector<u8> const &buf)
 {
     this->reset();
 
-    lsh_bin_struct tmp = (lsh_bin_struct &)buf[0];
+    if (buf.size() != sizeof(lsh_bin_struct))
+    {
+        return 1;
+    }
+
+    lsh_bin_struct tmp{};
+    ::memcpy(&tmp, &buf[0], sizeof(lsh_bin_struct));
+
     // Reconstruct checksum, Qrations & lvalue
     for (int k = 0; k < TLSH_CHECKSUM_LEN; k++)
     {
@@ -1287,7 +1053,7 @@ TlshImpl::hash(std::vector<u8> &buffer, u8 showvers) const
 std::vector<u8> const &
 TlshImpl::hash(u8 showvers) const
 {
-    if (this->lsh_code.size())
+    if (!this->lsh_code.empty())
     {
         // lsh_code has been previously calculated, so just return it
         return this->lsh_code;

--- a/src/tlsh_util.cpp
+++ b/src/tlsh_util.cpp
@@ -2646,7 +2646,7 @@ swap_byte(const unsigned char in)
 void
 to_hex(u8 *psrc, int len, u8 *pdest)
 {
-    static unsigned char HexLookup[513] = {
+    const static u8 HexLookup[513] = {
         "000102030405060708090A0B0C0D0E0F"
         "101112131415161718191A1B1C1D1E1F"
         "202122232425262728292A2B2C2D2E2F"
@@ -2672,13 +2672,13 @@ to_hex(u8 *psrc, int len, u8 *pdest)
         pwDest++;
         psrc++;
     }
-    *((unsigned char *)pwDest) = 0; // terminate the string
+    // *((unsigned char *)pwDest) = 0; // terminate the string // off-by-one
 }
 
 void
 from_hex(std::vector<u8> const &psrc, std::vector<u8> &pdest)
 {
-    static std::array<u8, 103> DecLookup = {
+    const static std::array<u8, 103> DecLookup = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // gap before first hex digit
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,       // 0123456789
@@ -2688,20 +2688,21 @@ from_hex(std::vector<u8> const &psrc, std::vector<u8> &pdest)
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // TUVWXYZ[/]^_` (gap)
         10, 11, 12, 13, 14, 15                 // abcdef
     };
-    
-    if (psrc.size() % 2 != 0){ 
+
+    if (psrc.size() & 1)
+    {
+        pdest.clear();
         return;
     }
 
     pdest.resize(psrc.size() / 2);
-    
-    for (int i = 0, j = 0; i < psrc.size() - 1; i += 2, j++)
-    {
-        const u8 hi = DecLookup[psrc[i]] << 4; 
-        const u8 lo = DecLookup[psrc[i + 1]]; 
-        pdest[j] = hi | lo; 
-    }
 
+    for (size_t i = 0, j = 0; i < psrc.size(); i += 2, j++)
+    {
+        const u8 hi = DecLookup[psrc[i]] << 4;
+        const u8 lo = DecLookup[psrc[i + 1]];
+        pdest[j]    = hi | lo;
+    }
 }
 
 
@@ -2712,7 +2713,7 @@ from_hex(std::vector<u8> const &psrc, std::vector<u8> &pdest)
 //     std::vector<u8> vecdst;
 //     vecsrc.assign(psrc, psrc+srclen);
 //     vecdst.assign(pdest, pdest+dstlen);
-   
+
 //     from_hex(vecsrc, vecdst);
 //     std::copy(vecdst.begin(), vecdst.end(), pdest);
 // }


### PR DESCRIPTION
There is an off-by-one in `to_hex` (null byte OOB write) resulting in the module crash when running for a while.

Found by ASAN

```text
==10996==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12ab094a0928 at pc 0x7ff8602c914d bp 0x00e354bebb60 sp 0x00e354bebb68
WRITE of size 1 at 0x12ab094a0928 thread T0
    #0 0x7ff8602c914c in to_hex C:\git\tlsh\src\tlsh_util.cpp:2675
    #1 0x7ff8602b73ce in TlshImpl::hash C:\git\tlsh\src\tlsh_impl.cpp:1042
    #2 0x7ff8602b6ba9 in TlshImpl::hash C:\git\tlsh\src\tlsh_impl.cpp:1065
    #3 0x7ff8602c7c4b in Tlsh::getHash C:\git\tlsh\src\tlsh.cpp:152
    #4 0x7ff8602828c6 in `nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::operator() C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:248
    #5 0x7ff860283b22 in `nanobind::detail::func_create<0,1,`nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>,std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh const *,unsigned char,0,1,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::operator() C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:153
    #6 0x7ff860272654 in `nanobind::detail::func_create<0,1,`nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>,std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh const *,unsigned char,0,1,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::<lambda_invoker_cdecl> C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:163
    #7 0x7ff86029c360 in nanobind::detail::nb_func_vectorcall_simple C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\src\nb_func.cpp:758
    #8 0x7ff871a495c6 in PyObject_Vectorcall+0x5e6 (C:\python311\python311.dll+0x1800395c6)
    #9 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #10 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #11 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #12 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #13 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #14 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #15 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #16 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #17 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #18 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #19 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #20 0x7ff871a582b2 in PyObject_MakeTpCall+0x3a2 (C:\python311\python311.dll+0x1800482b2)
    #21 0x7ff871a4926e in PyObject_Vectorcall+0x28e (C:\python311\python311.dll+0x18003926e)
    #22 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #23 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #24 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #25 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #26 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #27 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #28 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #29 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #30 0x7ff871a66cc0 in PyObject_CallObject+0x430 (C:\python311\python311.dll+0x180056cc0)
    #31 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #32 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #33 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #34 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #35 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #36 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #37 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #38 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #39 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #40 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #41 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #42 0x7ff871a582b2 in PyObject_MakeTpCall+0x3a2 (C:\python311\python311.dll+0x1800482b2)
    #43 0x7ff871a4926e in PyObject_Vectorcall+0x28e (C:\python311\python311.dll+0x18003926e)
    #44 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #45 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #46 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #47 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #48 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #49 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #50 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #51 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #52 0x7ff871a582b2 in PyObject_MakeTpCall+0x3a2 (C:\python311\python311.dll+0x1800482b2)
    #53 0x7ff871a4926e in PyObject_Vectorcall+0x28e (C:\python311\python311.dll+0x18003926e)
    #54 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #55 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #56 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #57 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #58 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #59 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #60 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #61 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #62 0x7ff871a582b2 in PyObject_MakeTpCall+0x3a2 (C:\python311\python311.dll+0x1800482b2)
    #63 0x7ff871a4926e in PyObject_Vectorcall+0x28e (C:\python311\python311.dll+0x18003926e)
    #64 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #65 0x7ff871a7a4f6 in PyMapping_Check+0x1ea (C:\python311\python311.dll+0x18006a4f6)
    #66 0x7ff871a78a3a in PyEval_EvalCode+0x96 (C:\python311\python311.dll+0x180068a3a)
    #67 0x7ff871afc48f in Py_SourceAsString+0x3db (C:\python311\python311.dll+0x1800ec48f)
    #68 0x7ff871afc35f in Py_SourceAsString+0x2ab (C:\python311\python311.dll+0x1800ec35f)
    #69 0x7ff871a5fccf in PyUnicode_RichCompare+0x1eef (C:\python311\python311.dll+0x18004fccf)
    #70 0x7ff871a495c6 in PyObject_Vectorcall+0x5e6 (C:\python311\python311.dll+0x1800395c6)
    #71 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #72 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #73 0x7ff871a67016 in PyObject_Call+0x5a (C:\python311\python311.dll+0x180057016)
    #74 0x7ff871a9e217 in PyObject_GetDictPtr+0x133 (C:\python311\python311.dll+0x18008e217)
    #75 0x7ff871b0355a in Py_EncodeUTF8Ex+0x6f6 (C:\python311\python311.dll+0x1800f355a)
    #76 0x7ff871b037c0 in Py_RunMain+0x14 (C:\python311\python311.dll+0x1800f37c0)
    #77 0x7ff871b86cac in Py_Main+0x24 (C:\python311\python311.dll+0x180176cac)
    #78 0x7ff7d9ad122f  (C:\python311\python.exe+0x14000122f)
    #79 0x7ff8b8d67343 in BaseThreadInitThunk+0x13 (C:\WINDOWS\System32\KERNEL32.DLL+0x180017343)
    #80 0x7ff8bace26b0 in RtlUserThreadStart+0x20 (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800526b0)

0x12ab094a0928 is located 0 bytes to the right of 72-byte region [0x12ab094a08e0,0x12ab094a0928)
allocated by thread T0 here:
    #0 0x7ff8602c9825 in operator new D:\a\_work\1\s\src\vctools\asan\llvm\compiler-rt\lib\asan\asan_win_new_scalar_thunk.cpp:40
    #1 0x7ff8602871a2 in std::_Default_allocate_traits::_Allocate C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\xmemory:90
    #2 0x7ff8602741bd in std::_Allocate<16,std::_Default_allocate_traits,0> C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\xmemory:248
    #3 0x7ff86028a12f in std::allocator<unsigned char>::allocate C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\xmemory:982
    #4 0x7ff8602742c5 in std::_Allocate_at_least_helper<std::allocator<unsigned char> > C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\xmemory:2211      
    #5 0x7ff8602c4f2f in std::vector<unsigned char,std::allocator<unsigned char> >::_Resize_reallocate<std::_Value_init_tag> C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\vector:1522
    #6 0x7ff8602c4b96 in std::vector<unsigned char,std::allocator<unsigned char> >::_Resize<std::_Value_init_tag> C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\vector:1568
    #7 0x7ff8602c775e in std::vector<unsigned char,std::allocator<unsigned char> >::resize C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.39.33519\include\vector:1590    
    #8 0x7ff8602b6b6c in TlshImpl::hash C:\git\tlsh\src\tlsh_impl.cpp:1062
    #9 0x7ff8602c7c4b in Tlsh::getHash C:\git\tlsh\src\tlsh.cpp:152
    #10 0x7ff8602828c6 in `nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::operator() C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:248
    #11 0x7ff860283b22 in `nanobind::detail::func_create<0,1,`nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>,std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh const *,unsigned char,0,1,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::operator() C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:153
    #12 0x7ff860272654 in `nanobind::detail::func_create<0,1,`nanobind::cpp_function_def<std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh,unsigned char,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>,std::basic_string<char,std::char_traits<char>,std::allocator<char> > const ,Tlsh const *,unsigned char,0,1,nanobind::scope,nanobind::name,nanobind::is_method>'::`2'::<lambda_1>::<lambda_invoker_cdecl> C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\include\nanobind\nb_func.h:163
    #13 0x7ff86029c360 in nanobind::detail::nb_func_vectorcall_simple C:\Users\chris\AppData\Local\Temp\pip-build-env-csp14ltk\overlay\Lib\site-packages\nanobind\src\nb_func.cpp:758
    #14 0x7ff871a495c6 in PyObject_Vectorcall+0x5e6 (C:\python311\python311.dll+0x1800395c6)
    #15 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)
    #16 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #17 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #18 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #19 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #20 0x7ff871a66c96 in PyObject_CallObject+0x406 (C:\python311\python311.dll+0x180056c96)
    #21 0x7ff871a4f524 in PyEval_EvalFrameDefault+0x5394 (C:\python311\python311.dll+0x18003f524)
    #22 0x7ff871a42263 in PyFunction_Vectorcall+0x1a3 (C:\python311\python311.dll+0x180032263)
    #23 0x7ff871a7ac01 in PyObject_FastCallDictTstate+0xc1 (C:\python311\python311.dll+0x18006ac01)
    #24 0x7ff871a79382 in PyObject_Call_Prepend+0x7e (C:\python311\python311.dll+0x180069382)
    #25 0x7ff871a792af in PyDict_GetItemStringWithError+0x19b (C:\python311\python311.dll+0x1800692af)
    #26 0x7ff871a582b2 in PyObject_MakeTpCall+0x3a2 (C:\python311\python311.dll+0x1800482b2)
    #27 0x7ff871a4926e in PyObject_Vectorcall+0x28e (C:\python311\python311.dll+0x18003926e)
    #28 0x7ff871a4a92a in PyEval_EvalFrameDefault+0x79a (C:\python311\python311.dll+0x18003a92a)

SUMMARY: AddressSanitizer: heap-buffer-overflow C:\git\tlsh\src\tlsh_util.cpp:2675 in to_hex
Shadow bytes around the buggy address:
  0x04f26a7140d0: fd fa fa fa fa fa 00 00 00 00 00 00 00 00 06 fa
  0x04f26a7140e0: fa fa fa fa fd fd fd fd fd fd fd fd fd fa fa fa
  0x04f26a7140f0: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x04f26a714100: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fd fd
  0x04f26a714110: fd fd fd fd fd fd fd fd fa fa fa fa 00 00 00 00
=>0x04f26a714120: 00 00 00 00 00[fa]fa fa fa fa fd fd fd fd fd fd
  0x04f26a714130: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x04f26a714140: fd fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x04f26a714150: fa fa fa fa fd fd fd fd fd fd fd fd fd fa fa fa
  0x04f26a714160: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x04f26a714170: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==10996==ABORTING
```